### PR TITLE
Fix for Error while adding a new child to a workitem [#97]

### DIFF
--- a/rtcclient/workitem.py
+++ b/rtcclient/workitem.py
@@ -608,7 +608,10 @@ class Workitem(FieldBase):
 
         # retrieve current children
         cur_children = self.getChildren(returned_properties="dc:identifier")
-        cur_child_ids = [cur_child.identifier for cur_child in cur_children]
+        if cur_children:
+            cur_child_ids = [cur_child.identifier for cur_child in cur_children if cur_child]
+        else:
+            cur_child_ids = []
 
         # add current children to list
         for child_id in cur_child_ids:


### PR DESCRIPTION
The error is not in the addChild method of the workitem.
it's in the _addChildren method,
`cur_child_ids = [cur_child.identifier for cur_child in cur_children]`
at this line when we say `cur_child.identifier`, we will get error if cur_child is None.
This happens if the workitem doesn't have any children initially.

The issue is probably because we have used a list comprehension, which doesn't care if the iterable object is empty and that could be fixed with a simple check.