### PR TITLE
fix issue #103: Authentication not working for RTC 6.0.4 ccm and other issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,9 @@ rtcclient
 .. image:: https://api.travis-ci.org/dixudx/rtcclient.svg?branch=master
     :target: https://pypi.python.org/pypi/rtcclient
 
+.. image:: https://img.shields.io/badge/slack-rtcclient-blue.svg
+    :target: https://rtcclient.slack.com
+
 .. image:: https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg
     :target: https://saythanks.io/to/dixudx
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jinja2>=2.2
 requests>=2.10.0
 six
 xmltodict
+lxml

--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -110,6 +110,12 @@ class RTCClient(RTCBase):
             raise exception.RTCException("Authentication Failed: "
                                          "Invalid username or password")
 
+        # header changes in 6.0.3, issue #92
+        authfailedloc = resp.headers.get("Location")
+        if authfailedloc is not None and authfailedloc.endswith("authfailed"):
+            raise exception.RTCException("Authentication Failed: "
+                                         "Invalid username or password")
+
         # fix issue #68
         if not _allow_redirects:
             if resp.headers.get("set-cookie") is not None:

--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -1070,7 +1070,7 @@ class RTCClient(RTCBase):
         wi_url_post = "/".join([self.url,
                                 "oslc/contexts",
                                 projectarea_id,
-                                "workitems/%s" % itemtype.identifier.lower()])
+                                "workitems/%s" % itemtype.identifier])
         return self._createWorkitem(wi_url_post, wi_raw)
 
     def copyWorkitem(self, copied_from, title=None, description=None,
@@ -1102,10 +1102,13 @@ class RTCClient(RTCBase):
         self.log.info("Start to create a new <Workitem>, copied from "
                       "<Workitem %s>", copied_from)
 
+        projectarea = self.getProjectAreaByID(copied_wi.contextId)
+        itemtype = projectarea.getItemType(copied_wi.type)
+
         wi_url_post = "/".join([self.url,
                                 "oslc/contexts/%s" % copied_wi.contextId,
                                 "workitems",
-                                "%s" % copied_wi.type.lower()])
+                                "%s" % itemtype.identifier])
         wi_raw = self.templater.renderFromWorkitem(copied_from,
                                                    keep=True,
                                                    encoding="UTF-8",

--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -1070,7 +1070,7 @@ class RTCClient(RTCBase):
         wi_url_post = "/".join([self.url,
                                 "oslc/contexts",
                                 projectarea_id,
-                                "workitems/%s" % itemtype.identifier])
+                                "workitems/%s" % itemtype.identifier.lower()])
         return self._createWorkitem(wi_url_post, wi_raw)
 
     def copyWorkitem(self, copied_from, title=None, description=None,
@@ -1099,13 +1099,13 @@ class RTCClient(RTCBase):
             if prefix is not None:
                 description = prefix + description
 
-        self.log.info("Start to create a new <Workitem>, copied from ",
+        self.log.info("Start to create a new <Workitem>, copied from "
                       "<Workitem %s>", copied_from)
 
         wi_url_post = "/".join([self.url,
                                 "oslc/contexts/%s" % copied_wi.contextId,
                                 "workitems",
-                                "%s" % copied_wi.type.split("/")[-1]])
+                                "%s" % copied_wi.type.lower()])
         wi_raw = self.templater.renderFromWorkitem(copied_from,
                                                    keep=True,
                                                    encoding="UTF-8",

--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -14,6 +14,7 @@ from rtcclient.template import Templater
 from rtcclient import _search_path
 from rtcclient.query import Query
 import six
+from rtcclient.utils import capitalize
 
 
 class RTCClient(RTCBase):
@@ -1154,7 +1155,7 @@ class RTCClient(RTCBase):
         # get rdf:resource by keywords
         for keyword in kwargs.keys():
             try:
-                keyword_cls = eval("self.get" + keyword.capitalize())
+                keyword_cls = eval("self.get" + capitalize(keyword))
                 keyword_obj = keyword_cls(kwargs[keyword],
                                           projectarea_id=projectarea_id)
                 kwargs[keyword] = keyword_obj.url

--- a/rtcclient/template.py
+++ b/rtcclient/template.py
@@ -7,6 +7,7 @@ import jinja2.meta
 from rtcclient import exception
 from rtcclient import _search_path
 import six
+from rtcclient.utils import remove_empty_elements
 
 
 class Templater(RTCBase):
@@ -129,7 +130,9 @@ class Templater(RTCBase):
                                                 template_folder=None,
                                                 keep=keep,
                                                 encoding=encoding))
-        return temp.render(**kwargs)
+
+        rendered_data = temp.render(**kwargs)
+        return remove_empty_elements(rendered_data)
 
     def listFields(self, template):
         """List all the attributes to be rendered from the template file
@@ -328,9 +331,10 @@ class Templater(RTCBase):
                           ("rtc_cm:filedAgainst", "{{ filedAgainst }}")]
         for field in replace_fields:
             try:
-                wk_raw_data[field[0]]["@rdf:resource"] = field[1]
-                self.log.debug("Successfully replace field [%s] with [%s]",
-                               field[0], field[1])
+                if field[0] in wk_raw_data:
+                    wk_raw_data[field[0]]["@rdf:resource"] = field[1]
+                    self.log.debug("Successfully replace field [%s] with [%s]",
+                                   field[0], field[1])
             except:
                 self.log.warning("Cannot replace field [%s]", field[0])
                 continue
@@ -340,8 +344,7 @@ class Templater(RTCBase):
                           template_file_path)
 
         return xmltodict.unparse(raw_data, output=output,
-                                 encoding=encoding,
-                                 pretty=True)
+                                 encoding=encoding)
 
     def _remove_long_fields(self, wk_raw_data):
         """Remove long fields: These fields are can only customized after

--- a/rtcclient/template.py
+++ b/rtcclient/template.py
@@ -354,7 +354,7 @@ class Templater(RTCBase):
 
         match_str_list = ["rtc_cm:com.ibm.",
                           "calm:"]
-        for key in wk_raw_data.keys():
+        for key in list(wk_raw_data.keys()):
             for match_str in match_str_list:
                 if key.startswith(match_str):
                     try:

--- a/rtcclient/template.py
+++ b/rtcclient/template.py
@@ -8,6 +8,7 @@ from rtcclient import exception
 from rtcclient import _search_path
 import six
 from rtcclient.utils import remove_empty_elements
+from xml.sax.saxutils import escape
 
 
 class Templater(RTCBase):
@@ -72,6 +73,12 @@ class Templater(RTCBase):
         :return: the :class:`string` object
         :rtype: string
         """
+
+        if kwargs.get("title", None) is not None:
+            kwargs["title"] = escape(kwargs["title"])
+
+        if kwargs.get("description", None) is not None:
+            kwargs["description"] = escape(kwargs["description"])
 
         try:
             temp = self.environment.get_template(template)

--- a/rtcclient/utils.py
+++ b/rtcclient/utils.py
@@ -2,7 +2,8 @@ import logging
 import functools
 from xml.parsers.expat import ExpatError
 import xmltodict
-from rtcclient.exception import RTCException
+from rtcclient.exception import RTCException, BadValue
+import six
 
 
 def setup_basic_logging():
@@ -42,3 +43,22 @@ def token_expire_handler(func):
                     raise ExpatError(excp)
 
     return wrapper
+
+
+def capitalize(keyword):
+    """Only capitalize the first character and make the left unchanged
+
+    :param keyword: the input string
+    :return: the capitalized string
+    """
+
+    if keyword is None:
+        raise BadValue("Invalid value. None is not supported")
+
+    if isinstance(keyword, six.string_types):
+        if len(keyword) > 1:
+            return keyword[0].upper() + keyword[1:]
+        else:
+            return keyword.capitalize()
+    else:
+        raise BadValue("Input value %s is not string type" % keyword)

--- a/rtcclient/utils.py
+++ b/rtcclient/utils.py
@@ -4,6 +4,7 @@ from xml.parsers.expat import ExpatError
 import xmltodict
 from rtcclient.exception import RTCException, BadValue
 import six
+from lxml import etree
 
 
 def setup_basic_logging():
@@ -62,3 +63,12 @@ def capitalize(keyword):
             return keyword.capitalize()
     else:
         raise BadValue("Input value %s is not string type" % keyword)
+
+
+def remove_empty_elements(docs):
+    root = etree.fromstring(str(docs))
+    for element in root.xpath("//*[not(node())]"):
+        if "rdf:resource" not in etree.tostring(element):
+            element.getparent().remove(element)
+
+    return etree.tostring(root)

--- a/rtcclient/workitem.py
+++ b/rtcclient/workitem.py
@@ -608,7 +608,8 @@ class Workitem(FieldBase):
 
         # retrieve current children
         cur_children = self.getChildren(returned_properties="dc:identifier")
-        cur_child_ids = [cur_child.identifier for cur_child in cur_children]
+        cur_child_ids = [cur_child.identifier for cur_child
+                         in (cur_children or []) if cur_child is not None]
 
         # add current children to list
         for child_id in cur_child_ids:


### PR DESCRIPTION
The original issue was "ERROR client.RTCClient: not well-formed (invalid token): line 17, column 77".  At beginning, I didn't know much about Python rtcclient and RTC. After asking around and searching tons of on-line posts, I realized the issue was basically caused by failed RTC authentication.

Due to lack of knowledge, I went a long way to find the solution. The bad thing is I spent a lot time and effort. The good thing is I learned a lot along the way. I won't learn this much if I was given solution quickly or I found solution quickly.

One comment to the rtcclient package is I wish it has a debugging document which tells you how to debug it if the scripts don't work for you for some reason. In the document, it should have the following points:
1. Remind users that all response (GET, POST, PUT or DELETE) should be a xml file, not a HTML file. If you got  "ERROR client.RTCClient: not well-formed (invalid token): line 17, column 77", it means the response is a HTML file which means something is wrong with your request even though the response status is 200 (OK).
2. List some common issues, their possible causes and solutions.
3. Recommend to use Mozilla Firefox's plug-in tool Poster to debug it.

Here are the issues I found and their solutions. I found the root causes and solutions by reading on-line posts and try-error method so I may not fully understand why some of the solutions work.

1. Authentication issue:
Solution:
   a. In Example.py:
   Change line from: url = "https://your_domain:9443/jazz"
                                 myclient = RTCClient(url, username, password, ends_with_jazz=False)
                           to:  url = "https://rtc-ccm-1.int.xxx.com:9443/ccm"
                                 myclient = RTCClient(url, ends_with_jazz=False)

   b. In base.py:
   Add: "OSLC_CORE_VERSION = "2.0"" just below "CONTENT_XML = "text/xml""

   c. In client.py:
   Add two imports on top:
             import urllib
             import httplib2

   Change from:     def __init__(self, url, username, password, proxies=None, searchpath=None,
                 ends_with_jazz=True):
                    to: def __init__(self, url, proxies=None, searchpath=None, ends_with_jazz=False):

   Change def _get_headers(self) to:
        self.http = httplib2.Http()
        _headers = {"Content-Type": self.CONTENT_XML}
        _headers["Content-Type"] = self.CONTENT_URL_ENCODED
        _headers["Accept"] = self.CONTENT_XML
        _headers["OSLC-Core-Version"] = self.OSLC_CORE_VERSION

        # Start the authentication via j_security_check page
        # To do: update username and password with yours
        resp, content = self.http.request(self.url + '/web/j_security_check', 'POST', headers=_headers,
                                          body=urllib.urlencode({'j_username': "your_username", 'j_password': "your_password"}))
        # Save the new cookie returned here
        _headers["Cookie"] = resp["set-cookie"]

        return _headers

2. Got "ERROR client.RTCClient: 'oslc_cm:ChangeRequest':" when running "wk = myclient.getWorkitem(123456)":
Solution:
    In def getWorkitem( ) of client.py:
    Change from: workitem_raw = raw_data["oslc_cm:ChangeRequest"]
                      to: workitem_raw = raw_data["rdf:RDF"]

3. Query doesn't work:
For my project, I would like to run my query in RTC and get the result. My solution is specific suited for my project. It's not a generic one, but it works great. I created the following function at the end of client.py. It will run my saved query and output raw data. I run it through "query_result = myclient.getQueryResult()" in Example.py. It outputs work item's tile, url and parent url.

    def getQueryResult(self):
        self.http = httplib2.Http()
        # To do: update query ID "your_query_ID" in following line with your query's ID.
        resp, content = self.http.request(self.url + "/oslc/queries/your_query_ID/rtc_cm:results?oslc.select=rtc_cm:user,dcterms:title,rtc_cm:com.ibm.team.workitem.linktype.parentworkitem.parent", 'GET', headers=self.headers)
        raw_data = xmltodict.parse(content)

        return raw_data

So far, that's all I found.