### PR TITLE
Mask false positive on 302 response. 'Redirection'

### DIFF
--- a/rtcclient/base.py
+++ b/rtcclient/base.py
@@ -76,10 +76,11 @@ class RTCBase(object):
         self.log.debug("Get response from %s", url)
         response = requests.get(url, verify=verify, headers=headers,
                                 proxies=proxies, timeout=timeout, **kwargs)
-        if response.status_code != 200:
-            self.log.error('Failed GET request at <%s> with response: %s',
+        if response.status_code != 200 and response.status_code != 302:
+            self.log.error('Failed GET request at <%s> with response: %s (%d)',
                            url,
-                           response.content)
+                           response.content,
+                           response.status_code)
             response.raise_for_status()
         return response
 
@@ -115,10 +116,11 @@ class RTCBase(object):
                                  verify=verify, headers=headers,
                                  proxies=proxies, timeout=timeout, **kwargs)
 
-        if response.status_code not in [200, 201]:
-            self.log.error('Failed POST request at <%s> with response: %s',
+        if response.status_code not in [200, 201, 302]:
+            self.log.error('Failed POST request at <%s> with response: %s (%d)',
                            url,
-                           response.content)
+                           response.content,
+                           response.status_code)
             self.log.info(response.status_code)
             response.raise_for_status()
         return response


### PR DESCRIPTION
    False positive messsage:
    09:41:22 ERROR:Failed GET request at <https://xxx.xxx.xxx/xxxxxxxx/authenticated/identity> with response: b''
    09:41:22 ERROR:Failed POST request at <https://xxx.xxx.xxx/xxxxxxxx/authenticated/j_security_check> with response: b''

Signed-off-by: Branislav Curcic <branislav.curcic@intel.com>