### PR TITLE
Added auth tuple to the get request. Work with 6.0.6.1 and ELM version 7.0

### DIFF
--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -85,24 +85,11 @@ class RTCClient(RTCBase):
 
         _headers = {"Content-Type": self.CONTENT_XML}
         resp = self.get(self.url + "/authenticated/identity",
+                        auth=(self.username,self.password),
                         verify=False,
                         headers=_headers,
                         proxies=self.proxies,
                         allow_redirects=_allow_redirects)
-
-        _headers["Content-Type"] = self.CONTENT_URL_ENCODED
-        if resp.headers.get("set-cookie") is not None:
-            _headers["Cookie"] = resp.headers.get("set-cookie")
-
-        credentials = urlencode({"j_username": self.username,
-                                 "j_password": self.password})
-
-        resp = self.post(self.url + "/authenticated/j_security_check",
-                         data=credentials,
-                         verify=False,
-                         headers=_headers,
-                         proxies=self.proxies,
-                         allow_redirects=_allow_redirects)
 
         # authfailed
         authfailed = resp.headers.get("x-com-ibm-team-repository-web-auth-msg")
@@ -122,6 +109,7 @@ class RTCClient(RTCBase):
                 _headers["Cookie"] = resp.headers.get("set-cookie")
 
         resp = self.get(self.url + "/authenticated/identity",
+                        auth=(self.username,self.password),
                         verify=False,
                         headers=_headers,
                         proxies=self.proxies,


### PR DESCRIPTION
Hi,
I did this change as in discussion #112 
I have checked this with Jazz 6.0.6.1 and ELM Tool 7.0
This seems to work.
What i dont know whether this would work with the older version of tools. I only have access to the 6.0.6.1 and 7.0

Also i cannot find any documentation to uses the tests in the test folder so i couldnt do it. There seems to be some URL replacement that would be required. If someone can provide me with a clear guideline how to do that i can do that for this change.