### PR TITLE
feat: pass CA_BUNDLE string from RTCClient to RTCbase's methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/rtcclient/base.py
+++ b/rtcclient/base.py
@@ -267,7 +267,7 @@ class FieldBase(RTCBase):
         self.log.debug("Start initializing data from %s", self.url)
         resp = self.get(
             self.url,
-            verify=False,
+            verify=self.rtc_obj.verify,
             proxies=self.rtc_obj.proxies,
             headers=self.rtc_obj.headers,
         )
@@ -341,7 +341,7 @@ class FieldBase(RTCBase):
 
         resp = self.get(
             rdf_url,
-            verify=False,
+            verify=self.rtc_obj.verify,
             proxies=self.rtc_obj.proxies,
             headers=self.rtc_obj.headers,
         )

--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -2,6 +2,8 @@ import copy
 import logging
 from multiprocessing.pool import ThreadPool as Pool
 
+from typing import Union
+
 import six
 import xmltodict
 
@@ -55,7 +57,8 @@ class RTCClient(RTCBase):
                  password,
                  proxies=None,
                  searchpath=None,
-                 ends_with_jazz=True):
+                 ends_with_jazz=True,
+                 verify: Union[bool, str] = False):
         """Initialization
 
         See params above
@@ -64,6 +67,7 @@ class RTCClient(RTCBase):
         self.username = username
         self.password = password
         self.proxies = proxies
+        self.verify = verify
         RTCBase.__init__(self, url)
 
         if not isinstance(ends_with_jazz, bool):
@@ -90,7 +94,7 @@ class RTCClient(RTCBase):
         _headers = {"Content-Type": self.CONTENT_XML}
         resp = self.get(self.url + "/authenticated/identity",
                         auth=(self.username, self.password),
-                        verify=False,
+                        verify=self.verify,
                         headers=_headers,
                         proxies=self.proxies,
                         allow_redirects=_allow_redirects)
@@ -114,7 +118,7 @@ class RTCClient(RTCBase):
 
         resp = self.get(self.url + "/authenticated/identity",
                         auth=(self.username, self.password),
-                        verify=False,
+                        verify=self.verify,
                         headers=_headers,
                         proxies=self.proxies,
                         allow_redirects=_allow_redirects)
@@ -135,7 +139,7 @@ class RTCClient(RTCBase):
             temp_headers = {"Content-Type": self.CONTENT_URL_ENCODED}
             resp = self.post(self.url + "/authenticated/j_security_check",
                              data=post_data,
-                             verify=False,
+                             verify=self.verify,
                              headers=temp_headers,
                              proxies=self.proxies,
                              allow_redirects=True)
@@ -986,7 +990,7 @@ class RTCClient(RTCBase):
             else:
                 req_url = workitem_url
             resp = self.get(req_url,
-                            verify=False,
+                            verify=self.verify,
                             proxies=self.proxies,
                             headers=self.headers)
             raw_data = xmltodict.parse(resp.content)
@@ -1211,7 +1215,7 @@ class RTCClient(RTCBase):
         headers['Content-Type'] = self.OSLC_CR_XML
 
         resp = self.post(url_post,
-                         verify=False,
+                         verify=self.verify,
                          headers=headers,
                          proxies=self.proxies,
                          data=workitem_raw)
@@ -1454,7 +1458,7 @@ class RTCClient(RTCBase):
                   if projectarea_id else None)
 
         resp = self.get(resource_url,
-                        verify=False,
+                        verify=self.verify,
                         proxies=self.proxies,
                         headers=self.headers)
         raw_data = xmltodict.parse(resp.content)
@@ -1502,7 +1506,7 @@ class RTCClient(RTCBase):
             url_next = raw_data.get('oslc_cm:Collection').get('@oslc_cm:next')
             if url_next:
                 resp = self.get(url_next,
-                                verify=False,
+                                verify=self.verify,
                                 proxies=self.proxies,
                                 headers=self.headers)
                 raw_data = xmltodict.parse(resp.content)

--- a/rtcclient/models.py
+++ b/rtcclient/models.py
@@ -291,7 +291,9 @@ class Change(FieldBase):
 
         self.log.debug("Start fetching file from %s ..." % file_url)
 
-        resp = self.get(file_url, verify=self.rtc_obj.verify, headers=self.rtc_obj.headers)
+        resp = self.get(file_url,
+                        verify=self.rtc_obj.verify,
+                        headers=self.rtc_obj.headers)
         file_name = re.findall(r".+filename\*=UTF-8''(.+)",
                                resp.headers["content-disposition"])[0]
         file_path = os.path.join(file_folder, file_name)

--- a/rtcclient/models.py
+++ b/rtcclient/models.py
@@ -189,7 +189,7 @@ class ChangeSet(FieldBase):
             "%s?_mediaType=text/xml" % identifier
         ])
         resp = self.get(resource_url,
-                        verify=False,
+                        verify=self.rtc_obj.verify,
                         proxies=self.rtc_obj.proxies,
                         headers=self.rtc_obj.headers)
         raw_data = xmltodict.parse(resp.content).get("scm:ChangeSet")
@@ -291,7 +291,7 @@ class Change(FieldBase):
 
         self.log.debug("Start fetching file from %s ..." % file_url)
 
-        resp = self.get(file_url, verify=False, headers=self.rtc_obj.headers)
+        resp = self.get(file_url, verify=self.rtc_obj.verify, headers=self.rtc_obj.headers)
         file_name = re.findall(r".+filename\*=UTF-8''(.+)",
                                resp.headers["content-disposition"])[0]
         file_path = os.path.join(file_folder, file_name)

--- a/rtcclient/project_area.py
+++ b/rtcclient/project_area.py
@@ -52,7 +52,7 @@ class ProjectArea(FieldBase):
             [self.rtc_obj.url,
              "process/project-areas/%s/roles" % self.id])
         resp = self.get(roles_url,
-                        verify=False,
+                        verify=self.rtc_obj.verify,
                         proxies=self.rtc_obj.proxies,
                         headers=self.rtc_obj.headers)
 

--- a/rtcclient/template.py
+++ b/rtcclient/template.py
@@ -276,7 +276,7 @@ class Templater(RTCBase):
 
         workitem_url = "/".join([self.url, "oslc/workitems/%s" % copied_from])
         resp = self.get(workitem_url,
-                        verify=False,
+                        verify=self.rtc_obj.verify,
                         proxies=self.rtc_obj.proxies,
                         headers=self.rtc_obj.headers)
         raw_data = xmltodict.parse(resp.content)

--- a/rtcclient/workitem.py
+++ b/rtcclient/workitem.py
@@ -103,7 +103,7 @@ class Workitem(FieldBase):
         comments_url = "/".join([self.url, "rtc_cm:comments"])
         headers = copy.deepcopy(self.rtc_obj.headers)
         resp = self.get(comments_url,
-                        verify=False,
+                        verify=self.rtc_obj.verify,
                         proxies=self.rtc_obj.proxies,
                         headers=headers)
 
@@ -121,7 +121,7 @@ class Workitem(FieldBase):
         req_url = "/".join([comments_url, "oslc:comment"])
 
         resp = self.post(req_url,
-                         verify=False,
+                         verify=self.rtc_obj.verify,
                          headers=headers,
                          proxies=self.rtc_obj.proxies,
                          data=comment_msg)
@@ -233,7 +233,7 @@ class Workitem(FieldBase):
         subscribers_url = "".join(
             [self.url, "?oslc_cm.properties=rtc_cm:subscribers"])
         self.put(subscribers_url,
-                 verify=False,
+                 verify=self.rtc_obj.verify,
                  proxies=self.rtc_obj.proxies,
                  headers=headers,
                  data=xmltodict.unparse(raw_data))
@@ -246,7 +246,7 @@ class Workitem(FieldBase):
         headers["Accept"] = self.OSLC_CR_RDF
         headers["OSLC-Core-Version"] = "2.0"
         resp = self.get(subscribers_url,
-                        verify=False,
+                        verify=self.rtc_obj.verify,
                         proxies=self.rtc_obj.proxies,
                         headers=headers)
         headers["If-Match"] = resp.headers.get("etag")
@@ -541,7 +541,7 @@ class Workitem(FieldBase):
         parent_original = {parent_tag: [{"rdf:resource": parent_url}]}
 
         self.put(req_url,
-                 verify=False,
+                 verify=self.rtc_obj.verify,
                  proxies=self.rtc_obj.proxies,
                  headers=headers,
                  data=json.dumps(parent_original))
@@ -615,7 +615,7 @@ class Workitem(FieldBase):
             "linktype.parentworkitem.children"
         ])
         self.put(req_url,
-                 verify=False,
+                 verify=self.rtc_obj.verify,
                  headers=headers,
                  proxies=self.rtc_obj.proxies,
                  data=json.dumps(children_original))
@@ -667,7 +667,7 @@ class Workitem(FieldBase):
         parent_original = {parent_tag: []}
 
         self.put(req_url,
-                 verify=False,
+                 verify=self.rtc_obj.verify,
                  proxies=self.rtc_obj.proxies,
                  headers=headers,
                  data=json.dumps(parent_original))
@@ -736,7 +736,7 @@ class Workitem(FieldBase):
             "linktype.parentworkitem.children"
         ])
         self.put(req_url,
-                 verify=False,
+                 verify=self.rtc_obj.verify,
                  headers=headers,
                  proxies=self.rtc_obj.proxies,
                  data=json.dumps(children_original))
@@ -769,7 +769,7 @@ class Workitem(FieldBase):
             "internal.rest.IAttachmentRestService/"
         ])
         resp = self.post(req_url,
-                         verify=False,
+                         verify=self.rtc_obj.verify,
                          headers=headers,
                          proxies=self.rtc_obj.proxies,
                          params=params,
@@ -792,7 +792,7 @@ class Workitem(FieldBase):
 
         resp = self.post(attachment_collection_url,
                          payload,
-                         verify=False,
+                         verify=self.rtc_obj.verify,
                          headers=self.rtc_obj.headers,
                          proxies=self.rtc_obj.proxies)
         raw_data = xmltodict.parse(resp.content)


### PR DESCRIPTION
set CA_BUNDLE path as RTCClient's argument and pass it to all network methods of RTCbase .