### PR TITLE
fix: handle xmltodict 0.13.0 return dict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ PySocks>=1.5.6
 jinja2>=2.2
 requests>=2.10.0
 six
-xmltodict<=0.12.0
+xmltodict
 lxml

--- a/rtcclient/__init__.py
+++ b/rtcclient/__init__.py
@@ -18,7 +18,13 @@ except ImportError:
     from urllib.parse import unquote as urlunquote  # noqa: F401
 
 try:  # pragma no cover
-    from collections import OrderedDict
+    import xmltodict
+    _xml_to_dict_version = [int(x) for x in xmltodict.__version__.split('.')]
+    # on xmltodict >= 0.13 it returns a dict
+    if _xml_to_dict_version[0] == 0 and _xml_to_dict_version[1] >= 13:
+        OrderedDict = dict
+    else:
+        from collections import OrderedDict
 except ImportError:  # pragma no cover
     try:
         from ordereddict import OrderedDict


### PR DESCRIPTION
handling the correct type returned from xmltodict when its version is greater than 0.13.0