### PR TITLE
feat: add email used to search own queries

### DIFF
--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -492,15 +492,10 @@ class RTCClient(RTCBase):
                                          returned_properties=rp,
                                          filter_rule=filter_rule)
 
-    def getOwnedBy(self, email, projectarea_id=None, projectarea_name=None):
-
-        if not isinstance(email, six.string_types) or "@" not in email:
-            excp_msg = "Please specify a valid email address name"
-            self.log.error(excp_msg)
-            raise exception.BadValue(excp_msg)
+    def getOwnedBy(self, username, projectarea_id=None, projectarea_name=None):
 
         parse_result = urlparse.urlparse(self.url)
-        new_path = "/".join(["/jts/users", urlquote(email)])
+        new_path = "/".join(["/jts/users", urlquote(username)])
         new_parse_result = urlparse.ParseResult(scheme=parse_result.scheme,
                                                 netloc=parse_result.netloc,
                                                 path=new_path,

--- a/rtcclient/client.py
+++ b/rtcclient/client.py
@@ -55,6 +55,7 @@ class RTCClient(RTCBase):
                  url,
                  username,
                  password,
+                 email=None,
                  proxies=None,
                  searchpath=None,
                  ends_with_jazz=True,
@@ -68,6 +69,7 @@ class RTCClient(RTCBase):
 
         self.username = username
         self.password = password
+        self.email = email
         self.proxies = proxies
         self.verify = verify
         self.old_rtc_authentication = old_rtc_authentication

--- a/rtcclient/query.py
+++ b/rtcclient/query.py
@@ -188,7 +188,7 @@ class Query(RTCBase):
         self.log.info("Start to fetch my saved queries")
         return self.getAllSavedQueries(projectarea_id=projectarea_id,
                                        projectarea_name=projectarea_name,
-                                       creator=self.rtc_obj.username,
+                                       creator=self.rtc_obj.email,
                                        saved_query_name=saved_query_name)
 
     def runSavedQueryByUrl(self, saved_query_url, returned_properties=None):

--- a/rtcclient/query.py
+++ b/rtcclient/query.py
@@ -188,7 +188,7 @@ class Query(RTCBase):
         self.log.info("Start to fetch my saved queries")
         return self.getAllSavedQueries(projectarea_id=projectarea_id,
                                        projectarea_name=projectarea_name,
-                                       creator=self.rtc_obj.email,
+                                       creator=self.rtc_obj.username,
                                        saved_query_name=saved_query_name)
 
     def runSavedQueryByUrl(self, saved_query_url, returned_properties=None):

--- a/rtcclient/workitem.py
+++ b/rtcclient/workitem.py
@@ -253,11 +253,14 @@ class Workitem(FieldBase):
         raw_data = xmltodict.parse(resp.content)
         return headers, raw_data
 
-    def _add_subscriber(self, email, raw_data):
+    def _check_email_field(self, email):
         if not isinstance(email, six.string_types) or "@" not in email:
             excp_msg = "Please specify a valid email address name: %s" % email
             self.log.error(excp_msg)
             raise exception.BadValue(excp_msg)
+
+    def _add_subscriber(self, email, raw_data):
+        self._check_email_field(email)
 
         existed_flag = False
         new_subscriber = self.rtc_obj.getOwnedBy(email)
@@ -293,10 +296,7 @@ class Workitem(FieldBase):
         return existed_flag, raw_data
 
     def _remove_subscriber(self, email, raw_data):
-        if not isinstance(email, six.string_types) or "@" not in email:
-            excp_msg = "Please specify a valid email address name: %s" % email
-            self.log.error(excp_msg)
-            raise exception.BadValue(excp_msg)
+        self._check_email_field(email)
 
         missing_flag = True
         del_sub = self.rtc_obj.getOwnedBy(email)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -735,12 +735,13 @@ class TestRTCClient:
             assert member.email == "tester1@email.com"
 
         # test invalid emails
-        invalid_emails = [
-            None, "", u"", False, True, "test%40email.com", u"test%40email.com"
-        ]
-        for invalid_email in invalid_emails:
-            with pytest.raises(BadValue):
-                myrtcclient.getOwnedBy(invalid_email)
+        # email check is not done into getOwnedBy
+        #invalid_emails = [
+        #    None, "", u"", False, True, "test%40email.com", u"test%40email.com"
+        #]
+        #for invalid_email in invalid_emails:
+        #    with pytest.raises(BadValue):
+        #        myrtcclient.getOwnedBy(invalid_email)
 
     @pytest.fixture
     def mock_get_plannedfors(self, mocker):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -734,15 +734,6 @@ class TestRTCClient:
             assert member == member1
             assert member.email == "tester1@email.com"
 
-        # test invalid emails
-        # email check is not done into getOwnedBy
-        #invalid_emails = [
-        #    None, "", u"", False, True, "test%40email.com", u"test%40email.com"
-        #]
-        #for invalid_email in invalid_emails:
-        #    with pytest.raises(BadValue):
-        #        myrtcclient.getOwnedBy(invalid_email)
-
     @pytest.fixture
     def mock_get_plannedfors(self, mocker):
         mocked_get = mocker.patch("requests.get")


### PR DESCRIPTION
To retrieve own queries "getMySavedQueries" must use the username, but actually following exception happens due to a check in "getOwnedBy":

```
2023-04-05 14:26:29,214 INFO query:Query: Start to fetch my saved queries
2023-04-05 14:26:29,215 ERROR client.RTCClient: Please specify a valid email address name
Traceback (most recent call last):
  File "...\rtcclient\examples\how_to\workitem\get_workitem.py", line 41, in <module>
    _q = _query.getMySavedQueries()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\rtcclient\rtcclient\query.py", line 189, in getMySavedQueries
    return self.getAllSavedQueries(projectarea_id=projectarea_id,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\rtcclient\rtcclient\query.py", line 108, in getAllSavedQueries
    fcreator = self.rtc_obj.getOwnedBy(creator).url
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\rtcclient\rtcclient\client.py", line 500, in getOwnedBy
    raise exception.BadValue(excp_msg)
rtcclient.exception.BadValue: Please specify a valid email address name
python-BaseException

```